### PR TITLE
Turn watch off so tests don't hang

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,9 +5,10 @@ import path from 'path'
 export default defineConfig({
   plugins: [react()],
   test: {
-    environment: 'jsdom',
-		globals: true,
-    setupFiles: './src/lib/test-setup.ts',
+	  environment: 'jsdom',
+	  globals: true,
+	  setupFiles: './src/lib/test-setup.ts',
+	  watch:false
   },
 	resolve: {
     alias: {


### PR DESCRIPTION
Tests were hanging on both the actions runs, and on my local as the tests were set up more for development than for actions. This change turns watching test files off so the tests will complete, actions complete and classroom grading can occur. 